### PR TITLE
Reboot bind command fix

### DIFF
--- a/.config/sxhkd/sxhkdrc
+++ b/.config/sxhkd/sxhkdrc
@@ -38,7 +38,7 @@ super + Insert
 super + shift + x
 	prompt "Shutdown computer?" "sudo -A shutdown -h now"
 super + shift + BackSpace
-	prompt "Reboot computer?" "sudo -A shutdown -h now"
+	prompt "Reboot computer?" "sudo -A reboot"
 super + x
 	mpc pause; pauseallmpv; i3lock -e -f -c 1d2021; xset dpms force off
 XF86Launch1


### PR DESCRIPTION
The reboot bind command has been changed from `sudo -A shutdown -h now` to `sudo -A reboot`.